### PR TITLE
adds transform-origin to CSS for non-chrome browsers

### DIFF
--- a/_posts/0001-01-08-winding-order.md
+++ b/_posts/0001-01-08-winding-order.md
@@ -34,7 +34,7 @@ In order for renderers to appropriately distinguish which polygons are holes and
         </svg>
       </div>
       <div class="col3 pad1">
-        <svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400">
+        <svg xmlns="http://www.w3.org/2000/svg" width="220" height="220" viewBox="0 0 400 400">
           <circle cx="204.02" cy="200" r="126.77" class="ring outer render"/>
         </svg>
       </div>

--- a/css/site.css
+++ b/css/site.css
@@ -38,7 +38,12 @@ Winding order example
   height: 110%;
 }
 .ring {
-  stroke-miterlimit:10;
+  stroke-miterlimit: 10;
+  transform-origin: center;
+  -ms-transform-origin: center;
+  -moz-transform-origin: center;
+  -webkit-transform-origin: center;
+  -o-transform-origin: center;
 }
 .outer {
   fill:#0074D9;
@@ -56,11 +61,6 @@ Winding order example
 
 @-webkit-keyframes rotateCW {
   from {
-    transform-origin: center;
-    -ms-transform-origin: center;
-    -moz-transform-origin: center;
-    -webkit-transform-origin: center;
-    -o-transform-origin: center;
     -ms-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
     -webkit-transform: rotate(0deg);
@@ -68,11 +68,6 @@ Winding order example
     transform: rotate(0deg);
   }
   to {
-    transform-origin: center;
-    -ms-transform-origin: center;
-    -moz-transform-origin: center;
-    -webkit-transform-origin: center;
-    -o-transform-origin: center;
     -ms-transform: rotate(360deg);
     -moz-transform: rotate(360deg);
     -webkit-transform: rotate(360deg);
@@ -82,11 +77,6 @@ Winding order example
 }
 @keyframes rotateCW {
   from {
-    transform-origin: center;
-    -ms-transform-origin: center;
-    -moz-transform-origin: center;
-    -webkit-transform-origin: center;
-    -o-transform-origin: center;
     -ms-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
     -webkit-transform: rotate(0deg);
@@ -94,11 +84,6 @@ Winding order example
     transform: rotate(0deg);
   }
   to {
-    transform-origin: center;
-    -ms-transform-origin: center;
-    -moz-transform-origin: center;
-    -webkit-transform-origin: center;
-    -o-transform-origin: center;
     -ms-transform: rotate(360deg);
     -moz-transform: rotate(360deg);
     -webkit-transform: rotate(360deg);
@@ -108,11 +93,6 @@ Winding order example
 }
 @-webkit-keyframes rotateCCW {
   from {
-    transform-origin: center;
-    -ms-transform-origin: center;
-    -moz-transform-origin: center;
-    -webkit-transform-origin: center;
-    -o-transform-origin: center;
     -ms-transform: rotate(360deg);
     -moz-transform: rotate(360deg);
     -webkit-transform: rotate(360deg);
@@ -120,11 +100,6 @@ Winding order example
     transform: rotate(360deg);
   }
   to {
-    transform-origin: center;
-    -ms-transform-origin: center;
-    -moz-transform-origin: center;
-    -webkit-transform-origin: center;
-    -o-transform-origin: center;
     -ms-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
     -webkit-transform: rotate(0deg);
@@ -134,11 +109,6 @@ Winding order example
 }
 @keyframes rotateCCW {
   from {
-    transform-origin: center;
-    -ms-transform-origin: center;
-    -moz-transform-origin: center;
-    -webkit-transform-origin: center;
-    -o-transform-origin: center;
     -ms-transform: rotate(360deg);
     -moz-transform: rotate(360deg);
     -webkit-transform: rotate(360deg);
@@ -146,11 +116,6 @@ Winding order example
     transform: rotate(360deg);
   }
   to {
-    transform-origin: center;
-    -ms-transform-origin: center;
-    -moz-transform-origin: center;
-    -webkit-transform-origin: center;
-    -o-transform-origin: center;
     -ms-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
     -webkit-transform: rotate(0deg);

--- a/css/site.css
+++ b/css/site.css
@@ -56,6 +56,11 @@ Winding order example
 
 @-webkit-keyframes rotateCW {
   from {
+    transform-origin: center;
+    -ms-transform-origin: center;
+    -moz-transform-origin: center;
+    -webkit-transform-origin: center;
+    -o-transform-origin: center;
     -ms-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
     -webkit-transform: rotate(0deg);
@@ -63,6 +68,11 @@ Winding order example
     transform: rotate(0deg);
   }
   to {
+    transform-origin: center;
+    -ms-transform-origin: center;
+    -moz-transform-origin: center;
+    -webkit-transform-origin: center;
+    -o-transform-origin: center;
     -ms-transform: rotate(360deg);
     -moz-transform: rotate(360deg);
     -webkit-transform: rotate(360deg);
@@ -72,6 +82,11 @@ Winding order example
 }
 @keyframes rotateCW {
   from {
+    transform-origin: center;
+    -ms-transform-origin: center;
+    -moz-transform-origin: center;
+    -webkit-transform-origin: center;
+    -o-transform-origin: center;
     -ms-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
     -webkit-transform: rotate(0deg);
@@ -79,6 +94,11 @@ Winding order example
     transform: rotate(0deg);
   }
   to {
+    transform-origin: center;
+    -ms-transform-origin: center;
+    -moz-transform-origin: center;
+    -webkit-transform-origin: center;
+    -o-transform-origin: center;
     -ms-transform: rotate(360deg);
     -moz-transform: rotate(360deg);
     -webkit-transform: rotate(360deg);
@@ -88,6 +108,11 @@ Winding order example
 }
 @-webkit-keyframes rotateCCW {
   from {
+    transform-origin: center;
+    -ms-transform-origin: center;
+    -moz-transform-origin: center;
+    -webkit-transform-origin: center;
+    -o-transform-origin: center;
     -ms-transform: rotate(360deg);
     -moz-transform: rotate(360deg);
     -webkit-transform: rotate(360deg);
@@ -95,6 +120,11 @@ Winding order example
     transform: rotate(360deg);
   }
   to {
+    transform-origin: center;
+    -ms-transform-origin: center;
+    -moz-transform-origin: center;
+    -webkit-transform-origin: center;
+    -o-transform-origin: center;
     -ms-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
     -webkit-transform: rotate(0deg);
@@ -104,6 +134,11 @@ Winding order example
 }
 @keyframes rotateCCW {
   from {
+    transform-origin: center;
+    -ms-transform-origin: center;
+    -moz-transform-origin: center;
+    -webkit-transform-origin: center;
+    -o-transform-origin: center;
     -ms-transform: rotate(360deg);
     -moz-transform: rotate(360deg);
     -webkit-transform: rotate(360deg);
@@ -111,6 +146,11 @@ Winding order example
     transform: rotate(360deg);
   }
   to {
+    transform-origin: center;
+    -ms-transform-origin: center;
+    -moz-transform-origin: center;
+    -webkit-transform-origin: center;
+    -o-transform-origin: center;
     -ms-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
     -webkit-transform: rotate(0deg);


### PR DESCRIPTION
Adds transform-origin and vendor prefixes to address funky rotation animations in FF, Safari, etc. 

Safari before / after 

![rotation-fun](https://cloud.githubusercontent.com/assets/2365503/13622962/e3014976-e557-11e5-939e-7209a4e814d4.gif)

cc: @mapsam @jakepruitt 