### PR TITLE
Maps and Lists in feature properties

### DIFF
--- a/3.0/vector_tile.proto
+++ b/3.0/vector_tile.proto
@@ -24,7 +24,14 @@ message Tile {
                 optional sint64 sint_value = 6;
                 optional bool bool_value = 7;
 
-                extensions 8 to max;
+                // Even numbered elements refer to the nth key in the layer's keys list
+                // Odd numbered elements refer to the nth value in the layer's values list
+                repeated uint32 hash_value = 8 [ packed = true ];
+
+                // Each element refers to the nth value in the layer's values list
+                repeated uint32 list_value = 9 [ packed = true ];
+
+                extensions 10 to max;
         }
 
         // Features are described in section 4.2 of the specification

--- a/3.0/vector_tile.proto
+++ b/3.0/vector_tile.proto
@@ -15,7 +15,8 @@ message Tile {
         // Variant type encoding
         // The use of values is described in section 4.1 of the specification
         message Value {
-                // Exactly one of these values must be present in a valid message
+                // No more than one of these values may be present in a valid message.
+                // If no value is written, the message is null.
                 optional string string_value = 1;
                 optional float float_value = 2;
                 optional double double_value = 3;


### PR DESCRIPTION
This is a proposed solution for the discussion in #75. This would allow for more complex properties such as:

```json
"my_key": { 
   "item1": [23,24,25], 
   "item3" : false, 
   "itemA":  {
      "a": "yes",
      "b": "no"
    }
},
"my_other_key": 12,
"my_final_key": false
```