### PR TITLE
Added spline types

### DIFF
--- a/3.0/README.md
+++ b/3.0/README.md
@@ -238,7 +238,7 @@ The command sequence in the `geometry` field for the control points in a spline 
 
 If the command sequence for a `SPLINE` geometry type includes only a single `MoveTo` command then the geometry MUST be interpreted as a single b-spline; otherwise the geometry MUST be interpreted as a multi b-spline geometry, wherein each `MoveTo` signals the beginning of a new b-spline.
 
-The `spline_knots` field MUST contain a sequence of complex values, each of which MUST be of the delta-encoded-list type, as defined in section 4.4.2.2 below. The number of such sequences MUST be the same as the number of b-splines specified in the `geometry`.
+The `spline_knots` field MUST contain a sequence of complex values, each of which MUST be of the delta-encoded-list type, as defined in section 4.4.2.2 below. The number of such complex values MUST be the same as the number of b-splines specified in the `geometry`.
 
 Each b-spline defined in the `geometry` field corresponds in sequence to one list of knot values in the `spline_knots` field. Each list of knot values for a b-spline MUST contain exactly the number of knot values defined by the following formula: `number_of_knots = number_of_control_points + degree + 1`.
 

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -225,6 +225,21 @@ Linear rings MUST be geometric objects that have no anomalous geometric points, 
 
 Polygon geometries MUST NOT have any interior rings that intersect and interior rings MUST be enclosed by the exterior ring.
 
+##### 4.3.5.3. Spline Geometry Type
+
+The `SPLINE` geometry type encodes a curve geometry in the form of a b-spline or basis spline. Unlike other geometry types, `SPLINE` requires the use of multiple fields in a feature. A spline geometry MUST have control points in the `geometry` field and knots in the `spline_knots` field. A spline geometry MAY have a degree in the `spline_degree` field.
+
+If a `SPLINE` geometry does not provide a degree in the `spline_degree` field, the degree is considered to be 2.
+
+The command sequence in the `geometry` field for the control points in a spline geometry MUST consist of one or more repetitions of the following sequence:
+
+1. A `MoveTo` command with a command count of 1
+2. A `LineTo` command with a command count greater than 0
+
+If the command sequence for a `SPLINE` geometry type includes only a single `MoveTo` command then the geometry MUST be interpreted as a single b-spline; otherwise the geometry MUST be interpreted as a multi b-spline geometry, wherein each `MoveTo` signals the beginning of a new b-spline.
+
+Each b-spline defined in the `geometry` field MUST have an array of knot values in the `spline_knots` field. Each array of knot values for a b-spline MUST contain exactly the number of knot values as defined by the following formula: `number_of_knots = number_of_control_points + degree + 1`. Knot values are encoded in the `spline_knots` field using delta-encoded-list complex value type as defined in 4.4.2.2 below. There will be delta-encoded-list for each b-spline.
+
 #### 4.3.6. Example Geometry Encodings
 
 ##### 4.3.6.1. Example Point

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -238,7 +238,9 @@ The command sequence in the `geometry` field for the control points in a spline 
 
 If the command sequence for a `SPLINE` geometry type includes only a single `MoveTo` command then the geometry MUST be interpreted as a single b-spline; otherwise the geometry MUST be interpreted as a multi b-spline geometry, wherein each `MoveTo` signals the beginning of a new b-spline.
 
-Each b-spline defined in the `geometry` field MUST have an array of knot values in the `spline_knots` field. Each array of knot values for a b-spline MUST contain exactly the number of knot values as defined by the following formula: `number_of_knots = number_of_control_points + degree + 1`. Knot values are encoded in the `spline_knots` field using delta-encoded-list complex value type as defined in 4.4.2.2 below. There will be delta-encoded-list for each b-spline.
+The `spline_knots` field MUST contain a sequence of complex values, each of which MUST be of the delta-encoded-list type, as defined in section 4.4.2.2 below. The number of such sequences MUST be the same as the number of b-splines specified in the `geometry`.
+
+Each b-spline defined in the `geometry` field corresponds in sequence to one list of knot values in the `spline_knots` field. Each list of knot values for a b-spline MUST contain exactly the number of knot values defined by the following formula: `number_of_knots = number_of_control_points + degree + 1`.
 
 #### 4.3.6. Example Geometry Encodings
 

--- a/3.0/vector_tile.proto
+++ b/3.0/vector_tile.proto
@@ -11,7 +11,6 @@ message Tile {
              LINESTRING = 2;
              POLYGON = 3;
              CURVE = 4;    // like a LineString, but a spline
-             AREA = 5;     // like a Polygon, but a spline
         }
 
         // Variant type encoding

--- a/3.0/vector_tile.proto
+++ b/3.0/vector_tile.proto
@@ -10,6 +10,8 @@ message Tile {
              POINT = 1;
              LINESTRING = 2;
              POLYGON = 3;
+             CURVE = 4;    // like a LineString, but a spline
+             AREA = 5;     // like a Polygon, but a spline
         }
 
         // Variant type encoding
@@ -81,6 +83,10 @@ message Tile {
                 // A string as a unique identifier for the Feature. Use either
                 // id or string_id, but not both. See spec section 4.2.
                 optional string string_id = 10;
+                
+                // Representation of spline knots to be clarified:
+                // https://github.com/mapbox/vector-tile-spec/issues/114
+                repeated double knots = 5 [ packed = true ];
         }
 
         // Layers are described in section 4.1 of the specification

--- a/3.0/vector_tile.proto
+++ b/3.0/vector_tile.proto
@@ -85,7 +85,7 @@ message Tile {
                 
                 // Representation of spline knots to be clarified:
                 // https://github.com/mapbox/vector-tile-spec/issues/114
-                repeated double knots = 5 [ packed = true ];
+                repeated double knots = 11 [ packed = true ];
         }
 
         // Layers are described in section 4.1 of the specification

--- a/3.0/vector_tile.proto
+++ b/3.0/vector_tile.proto
@@ -10,7 +10,7 @@ message Tile {
              POINT = 1;
              LINESTRING = 2;
              POLYGON = 3;
-             CURVE = 4;    // like a LineString, but a spline
+             SPLINE = 4;    // like a LineString, but a spline
         }
 
         // Variant type encoding
@@ -79,13 +79,14 @@ message Tile {
                 // elevation_scaling, if present.
                 repeated sint32 elevation = 7 [ packed = true];
 
+                repeated uint64 spline_knots = 8 [ packed = true ];
+
+                optional uint32 spline_degree = 9 [ default = 2];
+                
                 // A string as a unique identifier for the Feature. Use either
                 // id or string_id, but not both. See spec section 4.2.
                 optional string string_id = 10;
                 
-                // Representation of spline knots to be clarified:
-                // https://github.com/mapbox/vector-tile-spec/issues/114
-                repeated double knots = 11 [ packed = true ];
         }
 
         // Layers are described in section 4.1 of the specification

--- a/3.0/vector_tile.proto
+++ b/3.0/vector_tile.proto
@@ -81,7 +81,7 @@ message Tile {
 
                 repeated uint64 spline_knots = 8 [ packed = true ];
 
-                optional uint32 spline_degree = 9 [ default = 2];
+                optional uint32 spline_degree = 9;
                 
                 // A string as a unique identifier for the Feature. Use either
                 // id or string_id, but not both. See spec section 4.2.


### PR DESCRIPTION
Added the ability to encode features as splines of two types, the first being a curve and the other being and area. This is a possible solution for #114. Updates to the `README.md` of the spec have not  done yet. 