### PR TITLE
Add Explict Multigeometries by Flag in Feature

### DIFF
--- a/3.0/vector_tile.proto
+++ b/3.0/vector_tile.proto
@@ -44,6 +44,10 @@ message Tile {
                 // A detailed description on geometry encoding is located in 
                 // section 4.3 of the specification.
                 repeated uint32 geometry = 4 [ packed = true ];
+
+                // If present, marks the geometry as explicitly MultiPoint,
+                // MultiLineString, or MultiPolygon
+                optional bool multigeometry = 6;
         }
 
         // Layers are described in section 4.1 of the specification


### PR DESCRIPTION
Addresses issue #77 

Adds the ability to determine if an object is a multi- type by using a boolean flag within a Feature. 