### PR TITLE
Added tile zoom, x, y locations in layer

### DIFF
--- a/3.0/README.md
+++ b/3.0/README.md
@@ -44,6 +44,8 @@ A layer MUST contain a `name` field. A Vector Tile MUST NOT contain two or more 
 
 A layer MUST contain an `extent` that describes the width and height of the tile in integer coordinates. The geometries within the Vector Tile MAY extend past the bounds of the tile's area as defined by the `extent`. Geometries that extend past the tile's area as defined by `extent` are often used as a buffer for rendering features that overlap multiple adjacent tiles.
 
+A layer MAY contain information about its tile location in the `tile_x`, `tile_y`, and `tile_zoom` fields. If you have one of these fields you MUST have other the tile locations fields. 
+
 For example, if a tile has an `extent` of 4096, coordinate units within the tile refer to 1/4096th of its square dimensions. A coordinate of 0 is on the top or left edge of the tile, and a coordinate of 4096 is on the bottom or right edge. Coordinates from 1 through 4095 inclusive are fully within the extent of the tile, and coordinates less than 0 or greater than 4096 are fully outside the extent of the tile.  A point at `(1,10)` or `(4095,10)` is within the extent of the tile. A point at `(0,10)` or `(4096,10)` is on the edge of the extent. A point at `(-1,10)` or `(4097,10)` is outside the extent of the tile.
 
 Each feature in a layer (see below) may have one or more key-value pairs as its metadata.

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -44,7 +44,7 @@ A layer MUST contain a `name` field. A Vector Tile MUST NOT contain two or more 
 
 A layer MUST contain an `extent` that describes the width and height of the tile in integer coordinates. The geometries within the Vector Tile MAY extend past the bounds of the tile's area as defined by the `extent`. Geometries that extend past the tile's area as defined by `extent` are often used as a buffer for rendering features that overlap multiple adjacent tiles.
 
-A layer MAY contain information about its tile location in the `tile_x`, `tile_y`, and `tile_zoom` fields. If you have one of these fields you MUST have other the tile locations fields. 
+A layer MAY contain information about its tile location in the `tile_x`, `tile_y`, and `tile_zoom` fields. If you have one of these fields you MUST have the other tile locations fields. 
 
 For example, if a tile has an `extent` of 4096, coordinate units within the tile refer to 1/4096th of its square dimensions. A coordinate of 0 is on the top or left edge of the tile, and a coordinate of 4096 is on the bottom or right edge. Coordinates from 1 through 4095 inclusive are fully within the extent of the tile, and coordinates less than 0 or greater than 4096 are fully outside the extent of the tile.  A point at `(1,10)` or `(4095,10)` is within the extent of the tile. A point at `(0,10)` or `(4096,10)` is on the edge of the extent. A point at `(-1,10)` or `(4097,10)` is outside the extent of the tile.
 

--- a/3.0/vector_tile.proto
+++ b/3.0/vector_tile.proto
@@ -129,6 +129,9 @@ message Tile {
                 // by their index within this sequence in the Layer.
                 repeated Scaling attribute_scalings = 11;
 
+                optional uint32 tile_x = 12;
+                optional uint32 tile_y = 13;
+                optional uint32 tile_zoom = 14;
 
                 extensions 16 to max;
         }


### PR DESCRIPTION
Currently the readme in this pull request does not include detailed information on the value ranges allowed for zoom, x, y. We should consider how we add these in the written portion of the spec at a later point. 