### PR TITLE
Update License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ A specification for encoding tiled vector data.
 
 ## License
 
-The text of this specification is licensed under a
-[Creative Commons Attribution 3.0 United States License](http://creativecommons.org/licenses/by/3.0/us/).
-However, the use of this spec in products and code is entirely free:
-there are no royalties, restrictions, or requirements.
+This entire repo is licensed under the [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/). 
+(Versions 1 and 2 of the specification were previously licensed under the [Creative Commons Attribution 3.0 United States License](http://creativecommons.org/licenses/by/3.0/us/). You can keep using them under the old license and can consider them dual-licensed.)
+
 
 ## [Implementations](https://github.com/mapbox/vector-tile-spec/wiki/Implementations)
 


### PR DESCRIPTION
Update License section of README to match new Mozilla Public License and account for continued use by those relying on old license.