### PR TITLE
Update to use elevation data as an sint64

### DIFF
--- a/3.0/vector_tile.proto
+++ b/3.0/vector_tile.proto
@@ -75,7 +75,7 @@ message Tile {
         // Delta-encoded elevation for each vertex in the geometry.
         // These values are scaled and offset using the layer's
         // elevation_scaling, if present.
-        repeated sint32 elevations = 7 [ packed = true];
+        repeated sint64 elevations = 7 [ packed = true];
 
         repeated uint64 spline_knots = 8 [ packed = true ];
 


### PR DESCRIPTION
This changes the way that elevation data can be encoded in the protobuf. While normally we do not want to encourage values larger than int64 for normal encodings, when using elevation scaling it is still preferred to use int64 values slightly larger than int32 range rather than using doubles. 