### PR TITLE
Moves content from docs.mapbox.com into Vector Tile Spec GH repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,16 @@ there are no royalties, restrictions, or requirements.
 
 ## Versioning
 
-The specification is versioned based on `major.minor` notation. The `major` version will be incremented with any technical change to the specification format or way it should be interpreted. Changes to the `minor` version will be reserved for any clarification or correction of clerical errors associated with the specification language.
+The Mapbox Vector Tile Specification is versioned based on `major.minor` notation. The `major` version will be incremented with any technical change to the specification format or way it should be interpreted. Changes to the `minor` version will be reserved for any clarification or correction of clerical errors associated with the specification language.
 
-The `major` version in the specification name is synonymous with the `version` field in a Mapbox Vector Tile layer. See the `3.1. Layers` section for more details.
+The `major` version in the specification name is synonymous with the `version` field in a Mapbox Vector Tile layer. See the [Layers](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#41-layers) section of the Vector Tile Specification for more details.
 
+**Version** | **Date&nbsp;of&nbsp;release** | **Updates**
+-|-|-
+**`2.1`** | January 19, 2016| Correction to the wording in a few locations of the 2.0 specification.
+**`2.0`** | December 4, 2015 | The focus of version 2.0 of the Mapbox Vector Tile specification is the clarification of the intent of the intial version of the specification and the definition of interior and exterior rings within polygons. The fields within the protobuffer are more clearly defined in this version of the specification and the steps for decoders and encoders are more explicity declared.
+**`1.0.1`** | July 28, 2014 | Update `.proto` file to match [Protocol Buffer style guide](https://developers.google.com/protocol-buffers/docs/style), changed namespace
+**`1.0.0`** | April 13, 2014 | First release
 
 ## Contributing
 


### PR DESCRIPTION
Re: https://github.com/mapbox/documentation/issues/790 

Paired with https://github.com/mapbox/data-docs/pull/51 (see [vector-tiles-standards.md](https://github.com/mapbox/data-docs/blob/tilesets-content/src/pages/tilesets/guides/vector-tiles-standards.md))

- migrates versioning table from docs.mapbox.com to GitHub