### PR TITLE
Restore site styling with a self-contained stylesheet

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 <head>
   <title>Mapbox Vector Tile Specification</title>
   <meta charset="UTF-8">
-  <link href='https://www.mapbox.com/base/latest/base.css?v1.0' rel='stylesheet' />
+  <link href="css/base.css" rel="stylesheet">
   <link href="css/site.css" rel="stylesheet">
 </head>
 <body>

--- a/css/base.css
+++ b/css/base.css
@@ -1,0 +1,115 @@
+/*
+
+Grid, utility, button, and typography classes the layout and posts use,
+previously loaded from https://www.mapbox.com/base/latest/base.css (now 404).
+Type uses the system font stack, so the page needs no external stylesheet or font.
+
+*/
+
+/* Base typography */
+body,
+input,
+textarea {
+  color: #404040;
+  color: rgba(0, 0, 0, 0.75);
+  font: 15px/20px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  margin: 0;
+}
+body {
+  background: #fff;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  font-weight: 700;
+  margin: 0;
+}
+h1 { font-size: 30px; line-height: 40px; }
+h2 { font-size: 22px; line-height: 30px; padding: 5px 0; }
+h3 { font-size: 15px; line-height: 20px; }
+h4, h5, h6 { font-size: 12px; line-height: 20px; }
+
+p { margin-bottom: 20px; }
+p:last-child { margin-bottom: 0; }
+
+a,
+a > code {
+  color: #3887be;
+  text-decoration: none;
+}
+a:hover,
+a:hover > code {
+  color: #63b6e5;
+}
+
+code, pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
+}
+
+/* Grid */
+.col3 { float: left; width: 25.0000%; max-width: 300px; }
+.col5 { float: left; width: 41.6666%; max-width: 500px; }
+.col6 { float: left; width: 50.0000%; max-width: 600px; }
+.col8 { float: left; width: 66.6666%; max-width: 800px; }
+.col12 { width: 100%; display: block; }
+
+/* Utilities */
+.clearfix { display: block; }
+.clearfix:after {
+  content: '';
+  display: block;
+  height: 0;
+  clear: both;
+  visibility: hidden;
+}
+.fr { float: right; }
+.pad1 { padding: 10px; }
+.pad1y { padding-top: 10px; padding-bottom: 10px; }
+.pad2y { padding-top: 20px; padding-bottom: 20px; }
+.margin0 { margin-left: 4.1666%; }
+.fill-light { background: #f8f8f8; }
+
+/* Buttons (the intro call-to-action links) */
+.button {
+  background-color: #3887be;
+  color: #fff;
+  display: inline-block;
+  padding: 10px;
+  border: none;
+  border-radius: 3px;
+  font-weight: 700;
+  font-size: 12px;
+  line-height: 20px;
+  text-align: center;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.button:hover { color: #fff; }
+.button.fill-green { background-color: #56b881; }
+.button.stroke {
+  background-color: transparent;
+  box-shadow: 0 0 0 2px #3887be inset;
+  color: #3887be;
+}
+.button.stroke:hover {
+  color: #52a1d8;
+  box-shadow: 0 0 0 2px #52a1d8 inset;
+}
+.button.stroke.quiet {
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15) inset;
+  color: rgba(0, 0, 0, 0.5);
+}
+.button.stroke.quiet:hover {
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.3) inset;
+  color: rgba(0, 0, 0, 0.75);
+}
+
+/* Wordmark (was a sprite in the original; plain text here) */
+.mb-logo {
+  display: inline-block;
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 40px;
+  vertical-align: top;
+}


### PR DESCRIPTION
It looks like the Mapbox `base.css` is no longer available, which means the the gh-pages site styling at https://mapbox.github.io/vector-tile-spec is currently broken.

This PR re-adds a small self-contained reimplementation of only the classes this site uses. It repairs the look for the site.

**Before:**

<img width="927" height="485" alt="Screenshot 2026-06-27 at 6 41 50 PM" src="https://github.com/user-attachments/assets/81657794-ee42-4111-ad71-f50ad94d2097" />

**After:**

<img width="1126" height="532" alt="Screenshot 2026-06-27 at 6 41 40 PM" src="https://github.com/user-attachments/assets/d6b0b90a-7fa1-4f45-9a47-913feeab02a9" />

cc @tristen @flippmoke @yhahn